### PR TITLE
Doc generator: output details for different enums with the same name (fixes #227)

### DIFF
--- a/doc-generator/doc_formatter/csv_generator.py
+++ b/doc-generator/doc_formatter/csv_generator.py
@@ -179,7 +179,7 @@ class CsvGenerator(DocFormatter):
 
 
     def format_property_details(self, prop_name, prop_type, prop_description, enum, enum_details,
-                                supplemental_details, parent_prop_info, anchor=None, profile={}):
+                                supplemental_details, parent_prop_info, profile={}):
         """Generate a formatted table of enum information for inclusion in Property Details."""
 
         # Property details are not included in CSV output.

--- a/doc-generator/doc_formatter/csv_generator.py
+++ b/doc-generator/doc_formatter/csv_generator.py
@@ -275,7 +275,7 @@ class CsvGenerator(DocFormatter):
         return "\n".join(formatted)
 
 
-    def add_section(self, text, link_id=False):
+    def add_section(self, text, link_id=False, schema_ref=False):
         """ Rather than a top-level heading, for CSV we set the first column (schema name) """
         if ' ' in text:
             self.schema_name, self.schema_version = text.split(' ', 1)

--- a/doc-generator/doc_formatter/csv_generator.py
+++ b/doc-generator/doc_formatter/csv_generator.py
@@ -306,11 +306,6 @@ class CsvGenerator(DocFormatter):
             self.writer.writerow(row)
 
 
-    def add_property_details(self, formatted_details):
-        """Add a chunk of property details information for the current section/schema."""
-        self.this_section['property_details'].append(formatted_details)
-
-
     def add_registry_reqs(self, registry_reqs):
         """ CSV output doesn't include registry requirements. """
         pass

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -97,8 +97,8 @@ class DocFormatter:
         raise NotImplementedError
 
 
-    def add_section(self, text, link_id=False):
-        """ Add a top-level heading """
+    def add_section(self, text, link_id=False, schema_ref=False):
+        """ Add a container for all the information in a section """
         raise NotImplementedError
 
 
@@ -413,7 +413,7 @@ class DocFormatter:
                 section_name = schema_name
             else:
                 section_name = details['name_and_version']
-            self.add_section(section_name, schema_name)
+            self.add_section(section_name, schema_name, schema_ref)
             self.current_version = {}
 
             if profile.get('URIs'):
@@ -644,7 +644,7 @@ class DocFormatter:
                 if version:
                     ref_id += '_v' + version
 
-                cp_gen.add_section(prop_name, ref_id)
+                cp_gen.add_section(prop_name, ref_id, schema_ref)
                 cp_gen.add_json_payload(supplemental.get('jsonpayload'))
 
                 # Override with supplemental schema description, if provided
@@ -1480,10 +1480,8 @@ class DocFormatter:
                 # Format it as if it were a top-level object, and remove the rows here.
                 object_formatted = self.format_object_descr(schema_ref, prop_info, [], is_action)
                 obj_prop_name = prop_info.get('_prop_name')
-                anchor = schema_ref + '|details_combined_ref|' + obj_prop_name
                 object_as_details = self.format_as_prop_details(obj_prop_name, prop_info.get('_ref_description'),
-                                                                    object_formatted['rows'], anchor)
-                # TODO
+                                                                    object_formatted['rows'])
                 new_details = {obj_prop_name: {
                     prop_info.get('_ref_uri', '_inline'): {
                         'paths': [new_path],

--- a/doc-generator/doc_formatter/doc_formatter.py
+++ b/doc-generator/doc_formatter/doc_formatter.py
@@ -197,7 +197,7 @@ class DocFormatter:
 
 
     def format_property_details(self, prop_name, prop_type, prop_description, enum, enum_details,
-                                    supplemental_details, parent_prop_info, anchor=None, profile={}):
+                                    supplemental_details, parent_prop_info, profile={}):
         """Generate a formatted table of enum information for inclusion in Property Details."""
         raise NotImplementedError
 
@@ -1430,12 +1430,12 @@ class DocFormatter:
                 prop_enum_details = prop_info.get('enumLongDescriptions')
             else:
                 prop_enum_details = prop_info.get('enumDescriptions')
-            anchor = schema_ref + '|details|' + prop_name
+
             formatted_details = self.format_property_details(prop_name, prop_type, descr,
                                                                  prop_enum, prop_enum_details,
                                                                  supplemental_details,
                                                                  prop_info,
-                                                                 anchor=anchor, profile=profile)
+                                                                 profile=profile)
             prop_detail_key = prop_info.get('_ref_uri', '_inline')
             if prop_info.get('_in_items') and len(prop_path):
                 # In items, the prop_path is expected to include the prop name at this point.
@@ -1792,7 +1792,7 @@ class DocFormatter:
         return {'rows': output, 'details': details, 'action_details': action_details, 'promote_me': True}
 
 
-    def format_as_prop_details(self, prop_name, prop_description, rows, anchor=None):
+    def format_as_prop_details(self, prop_name, prop_description, rows):
         """ Take the formatted rows and other strings from prop_info, and create a formatted block suitable for the prop_details section """
         raise NotImplementedError
 

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -453,7 +453,6 @@ pre.code{
         """Generate a formatted table of enum information for inclusion in Property details."""
 
         contents = []
-        contents.append(self.formatter.head_four(html.escape(prop_name, False) + ':', self.level, anchor))
 
         parent_version = parent_prop_info.get('versionAdded')
         if parent_version:
@@ -744,7 +743,32 @@ pre.code{
             if section.get('property_details'):
                 deets = []
                 deets.append(self.formatter.head_three('Property details', self.level))
-                deets.append(self.formatter.make_div('\n'.join(section['property_details']),
+                # Sort and output property details
+                detail_names = [x for x in section['property_details'].keys()]
+                detail_names.sort(key=str.lower)
+                deets_content = []
+                for detail_name in detail_names:
+                    det_info = section['property_details'][detail_name]
+                    anchor = section['schema_ref'] + '|details|' + detail_name
+                    deets_content.append(self.formatter.head_four(html.escape(detail_name, False) + ':', 0, anchor))
+
+                    if len(det_info) == 1:
+                        for x in det_info.values():
+                            deets_content.append(x['formatted_descr'])
+                    else:
+                        path_to_ref = {}
+                        for ref, info in det_info.items():
+                            paths_as_text = [": ".join(x) for x in info['paths']]
+                            paths_as_text = ', '.join(paths_as_text)
+                            path_to_ref[paths_as_text] = ref
+                        paths_sorted = [x for x in path_to_ref.keys()]
+                        paths_sorted.sort(key=str.lower)
+                        for path in paths_sorted:
+                            info = det_info[path_to_ref[path]]
+                            deets_content.append(self.formatter.head_five("In " + path + ":", 0))
+                            deets_content.append(info['formatted_descr'])
+
+                deets.append(self.formatter.make_div('\n'.join(deets_content),
                                            'property-details-content'))
                 contents.append(self.formatter.make_div('\n'.join(deets), 'property-details'))
 
@@ -913,8 +937,8 @@ pre.code{
         return '\n'.join(intro)
 
 
-    def add_section(self, text, link_id=False):
-        """ Add a top-level heading """
+    def add_section(self, text, link_id=False, schema_ref=False):
+        """ Add a container for all the information in a section """
 
         self.this_section = {
             'properties': [],
@@ -929,6 +953,7 @@ pre.code{
             self.this_section['head'] = text
             self.this_section['heading'] = self.formatter.head_two(section_text, self.level, link_id)
             self.this_section['link_id'] = link_id
+            self.this_section['schema_ref'] = schema_ref or text
 
         self.sections.append(self.this_section)
 
@@ -1039,7 +1064,6 @@ pre.code{
     def format_as_prop_details(self, prop_name, prop_description, rows, anchor=None):
         """ Take the formatted rows and other strings from prop_info, and create a formatted block suitable for the prop_details section """
         contents = []
-        contents.append(self.formatter.head_four(html.escape(prop_name, False) + ':', 0, anchor))
 
         if prop_description:
             contents.append(self.formatter.para(prop_description))

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -449,7 +449,7 @@ pre.code{
 
 
     def format_property_details(self, prop_name, prop_type, prop_description, enum, enum_details,
-                                    supplemental_details, parent_prop_info, anchor=None, profile=None):
+                                    supplemental_details, parent_prop_info, profile=None):
         """Generate a formatted table of enum information for inclusion in Property details."""
 
         contents = []
@@ -1061,7 +1061,7 @@ pre.code{
             self.registry_sections.append(this_section)
 
 
-    def format_as_prop_details(self, prop_name, prop_description, rows, anchor=None):
+    def format_as_prop_details(self, prop_name, prop_description, rows):
         """ Take the formatted rows and other strings from prop_info, and create a formatted block suitable for the prop_details section """
         contents = []
 

--- a/doc-generator/doc_formatter/html_generator.py
+++ b/doc-generator/doc_formatter/html_generator.py
@@ -918,7 +918,7 @@ pre.code{
 
         self.this_section = {
             'properties': [],
-            'property_details': [],
+            'property_details': {},
             'head': '',
             'heading': ''
             }
@@ -997,11 +997,6 @@ pre.code{
 
         formatted_row should be a chunk of text already formatted for output"""
         self.this_section['properties'].append(formatted_text)
-
-
-    def add_property_details(self, formatted_details):
-        """Add a chunk of property details information for the current section/schema."""
-        self.this_section['property_details'].append(formatted_details)
 
 
     def add_registry_reqs(self, registry_reqs):

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -643,7 +643,27 @@ class MarkdownGenerator(DocFormatter):
                 contents.append('\n\n'.join(section.get('action_details')))
             if section.get('property_details'):
                 contents.append('\n' + self.formatter.head_two('Property details', self.level))
-                contents.append('\n'.join(section['property_details']))
+                detail_names = [x for x in section['property_details'].keys()]
+                detail_names.sort(key=str.lower)
+                for detail_name in detail_names:
+                    contents.append(self.formatter.head_three(detail_name + ':', 0))
+                    det_info = section['property_details'][detail_name]
+                    if len(det_info) == 1:
+                        for x in det_info.values():
+                            contents.append(x['formatted_descr'])
+                    else:
+                        path_to_ref = {}
+                        # Generate path descriptions and sort them.
+                        for ref, info in det_info.items():
+                            paths_as_text = [": ".join(x) for x in info['paths']]
+                            paths_as_text = ', '.join(paths_as_text)
+                            path_to_ref[paths_as_text] = ref
+                        paths_sorted = [x for x in path_to_ref.keys()]
+                        paths_sorted.sort(key=str.lower)
+                        for path in paths_sorted:
+                            info = det_info[path_to_ref[path]]
+                            contents.append(self.formatter.para(self.formatter.bold("In " + path + ":")))
+                            contents.append(info['formatted_descr'])
 
         self.sections = []
 
@@ -762,7 +782,7 @@ search: true
         self.this_section = {'head': text,
                              'heading': '\n' + self.formatter.head_one(text, self.level),
                              'properties': [],
-                             'property_details': []
+                             'property_details': {}
                             }
         self.sections.append(self.this_section)
 
@@ -805,11 +825,6 @@ search: true
 
         formatted_row should be a chunk of text already formatted for output"""
         self.this_section['properties'].append(formatted_text)
-
-
-    def add_property_details(self, formatted_details):
-        """Add a chunk of property details information for the current section/schema."""
-        self.this_section['property_details'].append(formatted_details)
 
 
     def add_registry_reqs(self, registry_reqs):

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -775,7 +775,7 @@ search: true
         return '\n'.join(intro)
 
 
-    def add_section(self, text, link_id=False):
+    def add_section(self, text, link_id=False, schema_ref=False):
         """ Add a top-level heading """
         self.this_section = {'head': text,
                              'heading': '\n' + self.formatter.head_one(text, self.level),

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -313,7 +313,6 @@ class MarkdownGenerator(DocFormatter):
         """Generate a formatted table of enum information for inclusion in Property details."""
 
         contents = []
-        contents.append(self.formatter.head_three(prop_name + ':', self.level))
 
         parent_version = parent_prop_info.get('versionAdded')
         if parent_version:
@@ -587,7 +586,6 @@ class MarkdownGenerator(DocFormatter):
     def format_as_prop_details(self, prop_name, prop_description, rows, anchor=None):
         """ Take the formatted rows and other strings from prop_info, and create a formatted block suitable for the prop_details section """
         contents = []
-        contents.append(self.formatter.head_three(prop_name + ':', 0))
 
         if prop_description:
             contents.append(self.formatter.para(self.escape_for_markdown(prop_description, self.config.get('escape_chars', []))))

--- a/doc-generator/doc_formatter/markdown_generator.py
+++ b/doc-generator/doc_formatter/markdown_generator.py
@@ -309,7 +309,7 @@ class MarkdownGenerator(DocFormatter):
 
 
     def format_property_details(self, prop_name, prop_type, prop_description, enum, enum_details,
-                                supplemental_details, parent_prop_info, anchor=None, profile=None):
+                                supplemental_details, parent_prop_info, profile=None):
         """Generate a formatted table of enum information for inclusion in Property details."""
 
         contents = []
@@ -583,7 +583,7 @@ class MarkdownGenerator(DocFormatter):
         return profile_access
 
 
-    def format_as_prop_details(self, prop_name, prop_description, rows, anchor=None):
+    def format_as_prop_details(self, prop_name, prop_description, rows):
         """ Take the formatted rows and other strings from prop_info, and create a formatted block suitable for the prop_details section """
         contents = []
 

--- a/doc-generator/doc_formatter/property_index_generator.py
+++ b/doc-generator/doc_formatter/property_index_generator.py
@@ -118,7 +118,7 @@ class PropertyIndexGenerator(DocFormatter):
 
         self.this_section = {
             'properties': [],
-            'property_details': [],
+            'property_details': {},
             'head': '',
             'heading': '',
             'schema_name': text

--- a/doc-generator/doc_formatter/property_index_generator.py
+++ b/doc-generator/doc_formatter/property_index_generator.py
@@ -211,7 +211,7 @@ class PropertyIndexGenerator(DocFormatter):
 
 
     def format_property_details(self, prop_name, prop_type, prop_description, enum, enum_details,
-                                supplemental_details, parent_prop_info, anchor=None, profile=None):
+                                supplemental_details, parent_prop_info, profile=None):
         """ Handle enum information """
         pass
 

--- a/doc-generator/doc_formatter/property_index_generator.py
+++ b/doc-generator/doc_formatter/property_index_generator.py
@@ -113,7 +113,7 @@ class PropertyIndexGenerator(DocFormatter):
         return output
 
 
-    def add_section(self, text, link_id=False):
+    def add_section(self, text, link_id=False, schema_ref=False):
         """ Start gathering info for this schema. """
 
         self.this_section = {

--- a/doc-generator/format_utils/format_utils.py
+++ b/doc-generator/format_utils/format_utils.py
@@ -32,6 +32,11 @@ class FormatUtils():
         add_level = '' + '#' * level
         return add_level + '##### ' + text + "\n"
 
+    def head_five(self, text, level, anchor_id=None):
+        """Add a fifth-level heading, relative to the generator's level"""
+        add_level = '' + '#' * level
+        return add_level + '###### ' + text + "\n"
+
     @staticmethod
     def para(text):
         """ Format text as a paragraph """

--- a/doc-generator/format_utils/html_utils.py
+++ b/doc-generator/format_utils/html_utils.py
@@ -42,6 +42,11 @@ class HtmlUtils(FormatUtils):
         level = str(level + 4)
         return self._head_base(text, level, anchor_id)
 
+    def head_five(self, text, level, anchor_id=None):
+        """ Make a fifth-level heading, relative to the current formatter level """
+        level = str(level + 5)
+        return self._head_base(text, level, anchor_id)
+
 
     @staticmethod
     def para(text):

--- a/doc-generator/tests/samples/properties_with_same_name/manager/Manager.json
+++ b/doc-generator/tests/samples/properties_with_same_name/manager/Manager.json
@@ -1,0 +1,25 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Manager.json",
+    "$ref": "#/definitions/Manager",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Manager": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Manager.v1_8_0.json#/definitions/Manager"
+                }
+            ],
+            "deletable": false,
+            "description": "In Redfish, a manager is a systems management entity that may implement or provide access to a Redfish service.  Examples of managers are BMCs, enclosure managers, management controllers, and other subsystems that are assigned manageability functions.  An implementation may have multiple managers, which may or may not be directly accessible through a Redfish-defined interface.",
+            "insertable": false,
+            "longDescription": "This resource shall represent a management subsystem for a Redfish implementation.",
+            "updatable": true,
+            "uris": [
+                "/redfish/v1/Managers/{ManagerId}"
+            ]
+        }
+    },
+    "owningEntity": "DMTF",
+    "title": "#Manager.Manager"
+}

--- a/doc-generator/tests/samples/properties_with_same_name/manager/Manager.v1_8_0.json
+++ b/doc-generator/tests/samples/properties_with_same_name/manager/Manager.v1_8_0.json
@@ -1,0 +1,700 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Manager.v1_8_0.json",
+    "$ref": "#/definitions/Manager",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Actions": {
+            "additionalProperties": false,
+            "description": "The available actions for this resource.",
+            "longDescription": "This type shall contain the available actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "#Manager.ForceFailover": {
+                    "$ref": "#/definitions/ForceFailover"
+                },
+                "#Manager.ModifyRedundancySet": {
+                    "$ref": "#/definitions/ModifyRedundancySet"
+                },
+                "#Manager.Reset": {
+                    "$ref": "#/definitions/Reset"
+                },
+                "#Manager.ResetToDefaults": {
+                    "$ref": "#/definitions/ResetToDefaults"
+                },
+                "Oem": {
+                    "$ref": "#/definitions/OemActions",
+                    "description": "The available OEM-specific actions for this resource.",
+                    "longDescription": "This property shall contain the available OEM-specific actions for this resource."
+                }
+            },
+            "type": "object"
+        },
+        "CommandConnectTypesSupported": {
+            "enum": [
+                "SSH",
+                "Telnet",
+                "IPMI",
+                "Oem"
+            ],
+            "enumDescriptions": {
+                "IPMI": "The controller supports a command shell connection through the IPMI Serial Over LAN (SOL) protocol.",
+                "Oem": "The controller supports a command shell connection through an OEM-specific protocol.",
+                "SSH": "The controller supports a command shell connection through the SSH protocol.",
+                "Telnet": "The controller supports a command shell connection through the Telnet protocol."
+            },
+            "type": "string"
+        },
+        "CommandShell": {
+            "additionalProperties": false,
+            "description": "The information about a command shell service that this manager provides.",
+            "longDescription": "This type shall describe a command shell service for a manager.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ConnectTypesSupported": {
+                    "description": "This property enumerates the command shell connection types that the implementation allows.",
+                    "items": {
+                        "$ref": "#/definitions/CommandConnectTypesSupported"
+                    },
+                    "longDescription": "This property shall contain an array of the enumerations.  SSH shall be included if the Secure Shell (SSH) protocol is supported.  Telnet shall be included if the Telnet protocol is supported.  IPMI shall be included if the IPMI Serial Over LAN (SOL) protocol is supported.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "MaxConcurrentSessions": {
+                    "description": "The maximum number of service sessions, regardless of protocol, that this manager can support.",
+                    "longDescription": "This property shall contain the maximum number of concurrent service sessions that this implementation supports.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": "integer"
+                },
+                "ServiceEnabled": {
+                    "description": "An indication of whether the service is enabled for this manager.",
+                    "longDescription": "This property shall indicate whether the protocol for the service is enabled.",
+                    "readonly": false,
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "ForceFailover": {
+            "additionalProperties": false,
+            "description": "The ForceFailover action forces a failover of this manager to the manager used in the parameter.",
+            "longDescription": "This action shall perform a forced failover of the manager's redundancy to the manager supplied as a parameter.",
+            "parameters": {
+                "NewManager": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Manager.json#/definitions/Manager",
+                    "description": "The manager to which to fail over.",
+                    "longDescription": "This parameter shall contain the manager to which to fail over.",
+                    "requiredParameter": true
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "GraphicalConnectTypesSupported": {
+            "enum": [
+                "KVMIP",
+                "Oem"
+            ],
+            "enumDescriptions": {
+                "KVMIP": "The controller supports a graphical console connection through a KVM-IP (redirection of Keyboard, Video, Mouse over IP) protocol.",
+                "Oem": "The controller supports a graphical console connection through an OEM-specific protocol."
+            },
+            "type": "string"
+        },
+        "GraphicalConsole": {
+            "additionalProperties": false,
+            "description": "The information about a graphical console service that this manager provides.",
+            "longDescription": "This type shall describe a graphical console service for a manager.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ConnectTypesSupported": {
+                    "description": "This property enumerates the graphical console connection types that the implementation allows.",
+                    "items": {
+                        "$ref": "#/definitions/GraphicalConnectTypesSupported"
+                    },
+                    "longDescription": "This property shall contain an array of the enumerations.  RDP shall be included if the Remote Desktop (RDP) protocol is supported.  KVMIP shall be included if a vendor-define KVM-IP protocol is supported.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "MaxConcurrentSessions": {
+                    "description": "The maximum number of service sessions, regardless of protocol, that this manager can support.",
+                    "longDescription": "This property shall contain the maximum number of concurrent service sessions that this implementation supports.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": "integer"
+                },
+                "ServiceEnabled": {
+                    "description": "An indication of whether the service is enabled for this manager.",
+                    "longDescription": "This property shall indicate whether the protocol for the service is enabled.",
+                    "readonly": false,
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "Manager": {
+            "additionalProperties": false,
+            "description": "In Redfish, a manager is a systems management entity that may implement or provide access to a Redfish service.  Examples of managers are BMCs, enclosure managers, management controllers, and other subsystems that are assigned manageability functions.  An implementation may have multiple managers, which may or may not be directly accessible through a Redfish-defined interface.",
+            "longDescription": "This resource shall represent a management subsystem for a Redfish implementation.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Actions": {
+                    "$ref": "#/definitions/Actions",
+                    "description": "The available actions for this resource.",
+                    "longDescription": "The actions property shall contain the available actions for this resource."
+                },
+                "AutoDSTEnabled": {
+                    "description": "An indication of whether the manager is configured for automatic Daylight Saving Time (DST) adjustment.",
+                    "longDescription": "This property shall indicate whether the manager is configured for automatic Daylight Saving Time (DST) adjustment.",
+                    "readonly": false,
+                    "type": "boolean",
+                    "versionAdded": "v1_4_0"
+                },
+                "CommandShell": {
+                    "$ref": "#/definitions/CommandShell",
+                    "description": "The command shell service that this manager provides.",
+                    "longDescription": "This property shall contain information about the command shell service of this manager."
+                },
+                "DateTime": {
+                    "description": "The current date and time with UTC offset that the manager uses to set or read time.",
+                    "format": "date-time",
+                    "longDescription": "This property shall represent the current DateTime value for the manager, with UTC offset, in Redfish Timestamp format.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "DateTimeLocalOffset": {
+                    "description": "The time offset from UTC that the DateTime property is in `+HH:MM` format.",
+                    "longDescription": "This property shall represent the offset from UTC time that the current DataTime property contains.",
+                    "pattern": "^([-+][0-1][0-9]:[0-5][0-9])$",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "FirmwareVersion": {
+                    "description": "The firmware version of this manager.",
+                    "longDescription": "This property shall contain the firwmare version as defined by the manufacturer for the associated manager.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "GraphicalConsole": {
+                    "$ref": "#/definitions/GraphicalConsole",
+                    "description": "The information about the graphical console (KVM-IP) service of this manager.",
+                    "longDescription": "This property shall contain the information about the graphical console (KVM-IP) service of this manager."
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "ManagerType": {
+                    "$ref": "#/definitions/ManagerType",
+                    "description": "The type of manager that this resource represents.",
+                    "longDescription": "This property shall describe the function of this manager.  The `ManagementController` value shall be used if none of the other enumerations apply.",
+                    "readonly": true
+                },
+                "Manufacturer": {
+                    "description": "The manufacturer of this manager.",
+                    "longDescription": "This property shall contain the name of the organization responsible for producing the manager.  This organization might be the entity from whom the manager is purchased, but this is not necessarily true.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_7_0"
+                },
+                "Model": {
+                    "description": "The model information of this manager, as defined by the manufacturer.",
+                    "longDescription": "This property shall contain the information about how the manufacturer refers to this manager.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                },
+                "PartNumber": {
+                    "description": "The part number of the manager.",
+                    "longDescription": "This property shall contain a part number assigned by the organization that is responsible for producing or manufacturing the manager.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_7_0"
+                },
+                "PowerState": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/PowerState"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The current power state of the manager.",
+                    "longDescription": "This property shall contain the power state of the manager.",
+                    "readonly": true,
+                    "versionAdded": "v1_2_0"
+                },
+                "RemoteRedfishServiceUri": {
+                    "description": "The URI of the Redfish service root for the remote manager that this resource represents.",
+                    "format": "uri-reference",
+                    "longDescription": "This property shall contain the URI of the Redfish service root for the remote manager that this resource represents.  This property shall only be present when providing aggregation of Redfish services.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "SerialConsole": {
+                    "$ref": "#/definitions/SerialConsole",
+                    "description": "The serial console service that this manager provides.",
+                    "longDescription": "This property shall contain information about the serial console service of this manager."
+                },
+                "SerialNumber": {
+                    "description": "The serial number of the manager.",
+                    "longDescription": "This property shall contain a manufacturer-allocated number that identifies the manager.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_7_0"
+                },
+                "ServiceEntryPointUUID": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/UUID"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The UUID of the Redfish service that is hosted by this manager.",
+                    "longDescription": "This property shall contain the UUID of the Redfish service that is hosted by this manager.  Each manager providing an entry point to the same Redfish service shall report the same UUID value, even though the name of the property may imply otherwise.  This property shall not be present if this manager does not provide a Redfish service entry point.",
+                    "readonly": true
+                },
+                "Status": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Status",
+                    "description": "The status and health of the resource and its subordinate or dependent resources.",
+                    "longDescription": "This property shall contain any status or health properties of the resource."
+                },
+                "UUID": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/UUID"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The UUID for this manager.",
+                    "longDescription": "This property shall contain the UUID for the manager.",
+                    "readonly": true
+                }
+            },
+            "required": [
+                "@odata.id",
+                "@odata.type",
+                "Id",
+                "Name"
+            ],
+            "type": "object"
+        },
+        "ManagerService": {
+            "additionalProperties": false,
+            "description": "The manager services, such as serial console, command shell, or graphical console service.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "MaxConcurrentSessions": {
+                    "description": "The maximum number of service sessions, regardless of protocol, that this manager can support.",
+                    "longDescription": "This property shall contain the maximum number of concurrent service sessions that this implementation supports.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": "integer"
+                },
+                "ServiceEnabled": {
+                    "description": "An indication of whether the service is enabled for this manager.",
+                    "longDescription": "This property shall indicate whether the protocol for the service is enabled.",
+                    "readonly": false,
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "ManagerType": {
+            "enum": [
+                "ManagementController",
+                "EnclosureManager",
+                "BMC",
+                "RackManager",
+                "AuxiliaryController",
+                "Service"
+            ],
+            "enumDescriptions": {
+                "AuxiliaryController": "A controller that provides management functions for a particular subsystem or group of devices.",
+                "BMC": "A controller that provides management functions for a single computer system.",
+                "EnclosureManager": "A controller that provides management functions for a chassis or group of devices or systems.",
+                "ManagementController": "A controller that primarily monitors or manages the operation of a device or system.",
+                "RackManager": "A controller that provides management functions for a whole or part of a rack.",
+                "Service": "A software-based service that provides management functions."
+            },
+            "enumVersionAdded": {
+                "Service": "v1_4_0"
+            },
+            "type": "string"
+        },
+        "ModifyRedundancySet": {
+            "additionalProperties": false,
+            "description": "The ModifyRedundancySet operation adds members to or removes members from a redundant group of managers.",
+            "longDescription": "The ModifyRedundancySet operation shall add members to or remove members from a redundant group of managers.",
+            "parameters": {
+                "Add": {
+                    "description": "An array of managers to add to the redundancy set.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Manager.json#/definitions/Manager"
+                    },
+                    "longDescription": "This parameter shall contain an array of managers to add to the redundancy set.",
+                    "type": "array"
+                },
+                "Remove": {
+                    "description": "An array of managers to remove from the redundancy set.",
+                    "items": {
+                        "$ref": "http://redfish.dmtf.org/schemas/v1/Manager.json#/definitions/Manager"
+                    },
+                    "longDescription": "This parameter shall contain an array of managers to remove from the redundancy set.",
+                    "type": "array"
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "OemActions": {
+            "additionalProperties": true,
+            "description": "The available OEM-specific actions for this resource.",
+            "longDescription": "This type shall contain the available OEM-specific actions for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "Reset": {
+            "additionalProperties": false,
+            "description": "The reset action resets/reboots the manager.",
+            "longDescription": "This action shall reset the manager.",
+            "parameters": {
+                "ResetType": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/ResetType",
+                    "description": "The type of reset.",
+                    "longDescription": "This parameter shall contain the type of reset.  The service may accept a request without the parameter and perform an implementation specific default reset."
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "ResetToDefaults": {
+            "additionalProperties": false,
+            "description": "The reset action resets the manager settings to factory defaults.  This may cause the manager to reset.",
+            "longDescription": "This action shall reset the manager settings.  This action may impact other resources.",
+            "parameters": {
+                "ResetType": {
+                    "$ref": "#/definitions/ResetToDefaultsType",
+                    "description": "The type of reset to defaults.",
+                    "longDescription": "This parameter shall contain the type of reset to defaults.",
+                    "requiredParameter": true
+                }
+            },
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "target": {
+                    "description": "Link to invoke action",
+                    "format": "uri-reference",
+                    "type": "string"
+                },
+                "title": {
+                    "description": "Friendly action name",
+                    "type": "string"
+                }
+            },
+            "type": "object",
+            "versionAdded": "v1_8_0"
+        },
+        "ResetToDefaultsType": {
+            "enum": [
+                "ResetAll",
+                "PreserveNetworkAndUsers",
+                "PreserveNetwork"
+            ],
+            "enumDescriptions": {
+                "PreserveNetwork": "Reset all settings except network settings to factory defaults.",
+                "PreserveNetworkAndUsers": "Reset all settings except network and local user names/passwords to factory defaults.",
+                "ResetAll": "Reset all settings to factory defaults."
+            },
+            "type": "string"
+        },
+        "SerialConnectTypesSupported": {
+            "enum": [
+                "SSH",
+                "Telnet",
+                "IPMI",
+                "Oem"
+            ],
+            "enumDescriptions": {
+                "IPMI": "The controller supports a serial console connection through the IPMI Serial Over LAN (SOL) protocol.",
+                "Oem": "The controller supports a serial console connection through an OEM-specific protocol.",
+                "SSH": "The controller supports a serial console connection through the SSH protocol.",
+                "Telnet": "The controller supports a serial console connection through the Telnet protocol."
+            },
+            "type": "string"
+        },
+        "SerialConsole": {
+            "additionalProperties": false,
+            "description": "The information about a serial console service that this manager provides.",
+            "longDescription": "This type shall describe a serial console service for a manager.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ConnectTypesSupported": {
+                    "description": "This property enumerates the serial console connection types that the implementation allows.",
+                    "items": {
+                        "$ref": "#/definitions/SerialConnectTypesSupported"
+                    },
+                    "longDescription": "This property shall contain an array of the enumerations.  SSH shall be included if the Secure Shell (SSH) protocol is supported.  Telnet shall be included if the Telnet protocol is supported.  IPMI shall be included if the IPMI Serial Over LAN (SOL) protocol is supported.",
+                    "readonly": true,
+                    "type": "array"
+                },
+                "MaxConcurrentSessions": {
+                    "description": "The maximum number of service sessions, regardless of protocol, that this manager can support.",
+                    "longDescription": "This property shall contain the maximum number of concurrent service sessions that this implementation supports.",
+                    "minimum": 0,
+                    "readonly": true,
+                    "type": "integer"
+                },
+                "ServiceEnabled": {
+                    "description": "An indication of whether the service is enabled for this manager.",
+                    "longDescription": "This property shall indicate whether the protocol for the service is enabled.",
+                    "readonly": false,
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2020.1",
+    "title": "#Manager.v1_8_0.Manager"
+}

--- a/doc-generator/tests/samples/properties_with_same_name/manager/Resource.json
+++ b/doc-generator/tests/samples/properties_with_same_name/manager/Resource.json
@@ -1,0 +1,336 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Resource.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "Description": {
+            "description": "The description of this resource.  Used for commonality in the schema definitions.",
+            "longDescription": "This object represents the description of this resource.  The resource values shall comply with the Redfish Specification-described requirements.",
+            "type": "string"
+        },
+        "Health": {
+            "enum": [
+                "OK",
+                "Warning",
+                "Critical"
+            ],
+            "enumDescriptions": {
+                "Critical": "A critical condition requires immediate attention.",
+                "OK": "Normal.",
+                "Warning": "A condition requires attention."
+            },
+            "type": "string"
+        },
+        "Id": {
+            "description": "The identifier that uniquely identifies the resource within the collection of similar resources.",
+            "longDescription": "This property represents an identifier for the resource.  The resource values shall comply with the Redfish Specification-described requirements.",
+            "type": "string"
+        },
+        "Identifier": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.v1_9_1.json#/definitions/Identifier"
+                }
+            ],
+            "description": "Any additional identifiers for a resource.",
+            "longDescription": "This type shall contain any additional identifiers for a resource."
+        },
+        "IndicatorLED": {
+            "enum": [
+                "Lit",
+                "Blinking",
+                "Off"
+            ],
+            "enumDescriptions": {
+                "Blinking": "The indicator LED is blinking.",
+                "Lit": "The indicator LED is lit.",
+                "Off": "The indicator LED is off."
+            },
+            "enumLongDescriptions": {
+                "Blinking": "This value shall represent that the indicator LED is in a blinking state where the LED is being turned on and off in repetition.  If the service does not support this value, it shall reject PATCH or PUT requests containing this value by returning the HTTP 400 (Bad Request) status code.",
+                "Lit": "This value shall represent that the indicator LED is in a solid on state.  If the service does not support this value, it shall reject PATCH or PUT requests containing this value by returning the HTTP 400 (Bad Request) status code.",
+                "Off": "This value shall represent that the indicator LED is in a solid off state.  If the service does not support this value, it shall reject PATCH or PUT requests containing this value by returning the HTTP 400 (Bad Request) status code."
+            },
+            "type": "string"
+        },
+        "Item": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/ReferenceableMember"
+                },
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Resource"
+                }
+            ],
+            "description": "The base type for resources and members that can be linked to."
+        },
+        "ItemOrCollection": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Item"
+                },
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/ResourceCollection"
+                }
+            ]
+        },
+        "Links": {
+            "additionalProperties": false,
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "type": "object"
+        },
+        "Location": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.v1_9_1.json#/definitions/Location"
+                }
+            ],
+            "description": "The location of a resource.",
+            "longDescription": "This type shall describe the location of a resource."
+        },
+        "Name": {
+            "description": "The name of the resource or array member.",
+            "longDescription": "This object represents the name of this resource or array member.  The resource values shall comply with the Redfish Specification-described requirements.  This string value shall be of the 'Name' reserved word format.",
+            "type": "string"
+        },
+        "Oem": {
+            "additionalProperties": true,
+            "description": "The OEM extension.",
+            "longDescription": "This object represents the OEM properties.  The resource values shall comply with the Redfish Specification-described requirements.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                },
+                "^[A-Za-z0-9_]+$": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/OemObject"
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "OemObject": {
+            "additionalProperties": true,
+            "description": "The base type for an OEM extension.",
+            "longDescription": "This object represents the base type for an OEM object.  The resource values shall comply with the Redfish Specification-described requirements.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {},
+            "type": "object"
+        },
+        "PowerState": {
+            "enum": [
+                "On",
+                "Off",
+                "PoweringOn",
+                "PoweringOff"
+            ],
+            "enumDescriptions": {
+                "Off": "The state is powered off.",
+                "On": "The state is powered on.",
+                "PoweringOff": "A temporary state between on and off.",
+                "PoweringOn": "A temporary state between off and on."
+            },
+            "type": "string"
+        },
+        "ReferenceableMember": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.v1_0_0.json#/definitions/ReferenceableMember"
+                }
+            ]
+        },
+        "ResetType": {
+            "enum": [
+                "On",
+                "ForceOff",
+                "GracefulShutdown",
+                "GracefulRestart",
+                "ForceRestart",
+                "Nmi",
+                "ForceOn",
+                "PushPowerButton",
+                "PowerCycle"
+            ],
+            "enumDescriptions": {
+                "ForceOff": "Turn off the unit immediately (non-graceful shutdown).",
+                "ForceOn": "Turn on the unit immediately.",
+                "ForceRestart": "Shut down immediately and non-gracefully and restart the system.",
+                "GracefulRestart": "Shut down gracefully and restart the system.",
+                "GracefulShutdown": "Shut down gracefully and power off.",
+                "Nmi": "Generate a diagnostic interrupt, which is usually an NMI on x86 systems, to stop normal operations, complete diagnostic actions, and, typically, halt the system.",
+                "On": "Turn on the unit.",
+                "PowerCycle": "Power cycle the unit.",
+                "PushPowerButton": "Simulate the pressing of the physical power button on this unit."
+            },
+            "enumVersionAdded": {
+                "PowerCycle": "v1_4_0"
+            },
+            "type": "string"
+        },
+        "Resource": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.v1_0_0.json#/definitions/Resource"
+                }
+            ]
+        },
+        "ResourceCollection": {
+            "anyOf": [
+                {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.v1_0_0.json#/definitions/ResourceCollection"
+                }
+            ]
+        },
+        "State": {
+            "enum": [
+                "Enabled",
+                "Disabled",
+                "StandbyOffline",
+                "StandbySpare",
+                "InTest",
+                "Starting",
+                "Absent",
+                "UnavailableOffline",
+                "Deferring",
+                "Quiesced",
+                "Updating",
+                "Qualified"
+            ],
+            "enumDescriptions": {
+                "Absent": "This function or resource is either not present or detected.",
+                "Deferring": "The element does not process any commands but queues new requests.",
+                "Disabled": "This function or resource is disabled.",
+                "Enabled": "This function or resource is enabled.",
+                "InTest": "This function or resource is undergoing testing, or is in the process of capturing information for debugging.",
+                "Qualified": "The element quality is within the acceptable range of operation.",
+                "Quiesced": "The element is enabled but only processes a restricted set of commands.",
+                "StandbyOffline": "This function or resource is enabled but awaits an external action to activate it.",
+                "StandbySpare": "This function or resource is part of a redundancy set and awaits a failover or other external action to activate it.",
+                "Starting": "This function or resource is starting.",
+                "UnavailableOffline": "This function or resource is present but cannot be used.",
+                "Updating": "The element is updating and may be unavailable or degraded."
+            },
+            "enumVersionAdded": {
+                "Deferring": "v1_2_0",
+                "Qualified": "v1_9_0",
+                "Quiesced": "v1_2_0",
+                "UnavailableOffline": "v1_1_0",
+                "Updating": "v1_2_0"
+            },
+            "type": "string"
+        },
+        "Status": {
+            "additionalProperties": false,
+            "description": "The status and health of a resource and its children.",
+            "longDescription": "This type shall contain any status or health properties of a resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "Health": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Health"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The health state of this resource in the absence of its dependent resources.",
+                    "longDescription": "This property shall represent the health state of the resource without considering its dependent resources.  The values shall conform to those defined in the Redfish Specification.",
+                    "readonly": true
+                },
+                "HealthRollup": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Health"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The overall health state from the view of this resource.",
+                    "longDescription": "This property shall represent the health state of the resource and its dependent resources.  The values shall conform to those defined in the Redfish Specification.",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                },
+                "State": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/State"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The known state of the resource, such as, enabled.",
+                    "longDescription": "This property shall indicate whether and why this component is available.  Enabled indicates the resource is available.  Disabled indicates the resource has been intentionally made unavailable but it can be enabled.  Offline indicates the resource is unavailable intentionally and requires action to make it available.  InTest indicates that the component is undergoing testing.  Starting indicates that the resource is becoming available.  Absent indicates the resource is physically unavailable.",
+                    "readonly": true
+                }
+            },
+            "type": "object"
+        },
+        "UUID": {
+            "pattern": "([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})",
+            "type": "string"
+        }
+    },
+    "owningEntity": "DMTF",
+    "title": "#Resource"
+}

--- a/doc-generator/tests/samples/properties_with_same_name/manager/Resource.v1_9_1.json
+++ b/doc-generator/tests/samples/properties_with_same_name/manager/Resource.v1_9_1.json
@@ -1,0 +1,1038 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/Resource.v1_9_1.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "copyright": "Copyright 2014-2020 DMTF. For the full DMTF copyright policy, see http://www.dmtf.org/about/policies/copyright",
+    "definitions": {
+        "ContactInfo": {
+            "additionalProperties": false,
+            "description": "Contact information for this resource.",
+            "longDescription": "This object shall contain contact information for an individual or organization responsible for this resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "ContactName": {
+                    "description": "Name of this contact.",
+                    "longDescription": "This property shall contain the name of a person or organization to contact for information about this resource.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_7_0"
+                },
+                "EmailAddress": {
+                    "description": "Email address for this contact.",
+                    "longDescription": "This property shall contain the email address for a person or organization to contact for information about this resource.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_7_0"
+                },
+                "PhoneNumber": {
+                    "description": "Phone number for this contact.",
+                    "longDescription": "This property shall contain the phone number for a person or organization to contact for information about this resource.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_7_0"
+                }
+            },
+            "type": "object"
+        },
+        "DurableNameFormat": {
+            "enum": [
+                "NAA",
+                "iQN",
+                "FC_WWN",
+                "UUID",
+                "EUI",
+                "NQN",
+                "NSID"
+            ],
+            "enumDescriptions": {
+                "EUI": "The IEEE-defined 64-bit Extended Unique Identifier (EUI).",
+                "FC_WWN": "The Fibre Channel (FC) World Wide Name (WWN).",
+                "NAA": "The Name Address Authority (NAA) format.",
+                "NQN": "The NVMe Qualified Name (NQN).",
+                "NSID": "The NVM Namespace Identifier (NSID).",
+                "UUID": "The Universally Unique Identifier (UUID).",
+                "iQN": "The iSCSI Qualified Name (iQN)."
+            },
+            "enumLongDescriptions": {
+                "EUI": "This durable name shall contain the hexadecimal representation of the IEEE-defined 64-bit Extended Unique Identifier (EUI), as defined in the IEEE's Guidelines for 64-bit Global Identifier (EUI-64) Specification.",
+                "FC_WWN": "This durable name shall contain a hexadecimal representation of the World-Wide Name (WWN) format, as defined in the T11 Fibre Channel Physical and Signaling Interface Specification.",
+                "NAA": "This durable name shall contain a hexadecimal representation of the Name Address Authority structure, as defined in the T11 Fibre Channel - Framing and Signaling - 3 (FC-FS-3) specification.",
+                "NQN": "This durable name shall be in the NVMe Qualified Name (NQN) format, as defined in the NVN Express over Fabric Specification.",
+                "NSID": "This durable name shall be in the NVM Namespace Identifier (NSID) format, as defined in the NVN Express Specification.",
+                "UUID": "This durable name shall contain the hexadecimal representation of the UUID, as defined in the International Telecom Union's OSI networking and system aspects - Naming, Addressing and Registration Specification.",
+                "iQN": "This durable name shall be in the iSCSI Qualified Name (iQN) format, as defined in RFC3720 and RFC3721."
+            },
+            "enumVersionAdded": {
+                "NQN": "v1_6_0",
+                "NSID": "v1_6_0"
+            },
+            "type": "string"
+        },
+        "Identifier": {
+            "additionalProperties": false,
+            "description": "Any additional identifiers for a resource.",
+            "longDescription": "This type shall contain any additional identifiers for a resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "DurableName": {
+                    "description": "The world-wide, persistent name of the resource.",
+                    "longDescription": "This property shall contain the world-wide unique identifier for the resource.  The string shall be in the Identifier.DurableNameFormat property value format.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0"
+                },
+                "DurableNameFormat": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/DurableNameFormat"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The format of the durable name property.",
+                    "longDescription": "This property shall represent the format of the DurableName property.",
+                    "readonly": true,
+                    "versionAdded": "v1_1_0"
+                }
+            },
+            "type": "object"
+        },
+        "Location": {
+            "additionalProperties": false,
+            "description": "The location of a resource.",
+            "longDescription": "This type shall describe the location of a resource.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AltitudeMeters": {
+                    "description": "The altitude of the resource in meters.",
+                    "longDescription": "This property shall contain the altitude of the resource in meters.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "m",
+                    "versionAdded": "v1_6_0"
+                },
+                "Contacts": {
+                    "description": "An array of contact information.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/ContactInfo"
+                            },
+                            {
+                                "type": "null"
+                            }
+                        ]
+                    },
+                    "longDescription": "This property shall contain an array of contact information for an individual or organization responsible for this resource.",
+                    "type": "array",
+                    "versionAdded": "v1_7_0"
+                },
+                "Info": {
+                    "deprecated": "This property has been deprecated in favor of the PostalAddress, Placement, and PartLocation properties.",
+                    "description": "The location of the resource.",
+                    "longDescription": "This property shall represent the location of the resource.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0",
+                    "versionDeprecated": "v1_5_0"
+                },
+                "InfoFormat": {
+                    "deprecated": "This property has been deprecated in favor of the PostalAddress, Placement, and PartLocation properties.",
+                    "description": "The format of the Info property.",
+                    "longDescription": "This property shall represent the Info property format.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_1_0",
+                    "versionDeprecated": "v1_5_0"
+                },
+                "Latitude": {
+                    "description": "The latitude of the resource.",
+                    "longDescription": "This property shall contain the latitude of the resource specified in degrees using a decimal format and not minutes or seconds.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "deg",
+                    "versionAdded": "v1_6_0"
+                },
+                "Longitude": {
+                    "description": "The longitude of the resource in degrees.",
+                    "longDescription": "This property shall contain the longitude of the resource specified in degrees using a decimal format and not minutes or seconds.",
+                    "readonly": false,
+                    "type": [
+                        "number",
+                        "null"
+                    ],
+                    "units": "deg",
+                    "versionAdded": "v1_6_0"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements.",
+                    "versionAdded": "v1_1_0"
+                },
+                "PartLocation": {
+                    "$ref": "#/definitions/PartLocation",
+                    "description": "The part location within the placement.",
+                    "longDescription": "The location within a resource.  This representation shall indicate the location within the Placement.",
+                    "versionAdded": "v1_5_0"
+                },
+                "Placement": {
+                    "$ref": "#/definitions/Placement",
+                    "description": "A place within the addressed location.",
+                    "longDescription": "This property shall contain a place within the addressed location.",
+                    "versionAdded": "v1_3_0"
+                },
+                "PostalAddress": {
+                    "$ref": "#/definitions/PostalAddress",
+                    "description": "The postal address of the addressed resource.",
+                    "longDescription": "This property shall contain a postal address of the resource.",
+                    "versionAdded": "v1_3_0"
+                }
+            },
+            "type": "object"
+        },
+        "LocationType": {
+            "description": "The location types for PartLocation.",
+            "enum": [
+                "Slot",
+                "Bay",
+                "Connector",
+                "Socket"
+            ],
+            "enumDescriptions": {
+                "Bay": "The bay as the type of location.",
+                "Connector": "The connector as the type of location.",
+                "Slot": "The slot as the type of location.",
+                "Socket": "The socket as the type of location."
+            },
+            "enumLongDescriptions": {
+                "Bay": "Bay shall indicate the type of PartLocation is of the Bay type.",
+                "Connector": "Connector shall indicate the type of PartLocation is of the Connector type.",
+                "Slot": "Slot shall indicate the type of PartLocation is of the Slot type.",
+                "Socket": "Socket shall indicate the type of PartLocation of the Socket type."
+            },
+            "longDescription": "Enumeration literals shall name the type of location in use.",
+            "type": "string"
+        },
+        "Orientation": {
+            "description": "The orientation for the ordering of the part location ordinal value.",
+            "enum": [
+                "FrontToBack",
+                "BackToFront",
+                "TopToBottom",
+                "BottomToTop",
+                "LeftToRight",
+                "RightToLeft"
+            ],
+            "enumDescriptions": {
+                "BackToFront": "The ordering for the LocationOrdinalValue is back to front.",
+                "BottomToTop": "The ordering for LocationOrdinalValue is bottom to top.",
+                "FrontToBack": "The ordering for LocationOrdinalValue is front to back.",
+                "LeftToRight": "The ordering for the LocationOrdinalValue is left to right.",
+                "RightToLeft": "The ordering for the LocationOrdinalValue is right to left.",
+                "TopToBottom": "The ordering for the LocationOrdinalValue is top to bottom."
+            },
+            "enumLongDescriptions": {
+                "BackToFront": "This value shall be used to indicate the ordering for LocationOrdinalValue is back to front.",
+                "BottomToTop": "This value shall be used to indicate the ordering for LocationOrdinalValue is bottom to top.",
+                "FrontToBack": "This value shall be used to indicate the ordering for LocationOrdinalValue is front to back.",
+                "LeftToRight": "This value shall be used to indicate the ordering for LocationOrdinalValue is left to right.",
+                "RightToLeft": "This value shall be used to indicate the ordering for LocationOrdinalValue is right to left.",
+                "TopToBottom": "This value shall be used to indicate the ordering for LocationOrdinalValue is top to bottom."
+            },
+            "longDescription": "These enumeration literals shall name the orientation for the location type ordering in determining the LocationOrdinalValue.",
+            "type": "string"
+        },
+        "PartLocation": {
+            "additionalProperties": false,
+            "description": "The part location within the placement.",
+            "longDescription": "This type shall describe a location within a resource.  This representation shall indicate the location within the Placement.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "LocationOrdinalValue": {
+                    "description": "The number that represents the location of the part.  If LocationType is `slot` and this unit is in slot 2, the LocationOrdinalValue is 2.",
+                    "longDescription": "This property shall contain the number that represents the location of the part based on the LocationType.  LocationOrdinalValue shall be measured based on the Orientation value starting with 0.",
+                    "readonly": true,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                },
+                "LocationType": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/LocationType"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of location of the part, such as slot, bay, socket and slot.",
+                    "longDescription": "This property shall contain the type of location of the part, such as slot, bay, socket and slot.",
+                    "readonly": true,
+                    "versionAdded": "v1_5_0"
+                },
+                "Orientation": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Orientation"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The orientation for the ordering of the slot enumeration used by the LocationOrdinalValue property.",
+                    "longDescription": "This property shall contain the orientation for the ordering used by the LocationOrdinalValue property.",
+                    "readonly": true,
+                    "versionAdded": "v1_5_0"
+                },
+                "Reference": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Reference"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The reference point for the part location.  Provides guidance about the general location of the part.",
+                    "longDescription": "This property shall contain the general location within the unit of the part.",
+                    "readonly": true,
+                    "versionAdded": "v1_5_0"
+                },
+                "ServiceLabel": {
+                    "description": "The label of the part location, such as a silk-screened name or a printed label.",
+                    "longDescription": "This property shall contain the label assigned for service at the part location.",
+                    "readonly": true,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_5_0"
+                }
+            },
+            "type": "object"
+        },
+        "Placement": {
+            "additionalProperties": false,
+            "description": "The placement within the addressed location.",
+            "longDescription": "The value shall describe a location within a resource.  Examples include a shelf in a rack.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AdditionalInfo": {
+                    "description": "Area designation or other additional info.",
+                    "longDescription": "This property shall contain additional information, such as Tile, Column (Post), Wall, or other designation that describes a location that cannot be conveyed with other properties defined for the Placement object.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_7_0"
+                },
+                "Rack": {
+                    "description": "The name of a rack location within a row.",
+                    "longDescription": "This property shall contain the name of the rack within a row.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "RackOffset": {
+                    "description": "The vertical location of the item, in terms of RackOffsetUnits.",
+                    "longDescription": "The vertical location of the item in the rack.  Rack offset units shall be measured from bottom to top, starting with 0.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "RackOffsetUnits": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/RackUnits"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "description": "The type of rack units in use.",
+                    "longDescription": "This property shall contain a RackUnit enumeration literal that indicates the type of rack units in use.",
+                    "readonly": false,
+                    "versionAdded": "v1_3_0"
+                },
+                "Row": {
+                    "description": "The name of the row.",
+                    "longDescription": "This property shall contain the name of the row.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                }
+            },
+            "type": "object"
+        },
+        "PostalAddress": {
+            "additionalProperties": false,
+            "description": "The postal address for a resource.",
+            "longDescription": "Instances shall describe a postal address for a resource.  For more information, see RFC5139.  Depending on use, the instance may represent a past, current, or future location.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "AdditionalCode": {
+                    "description": "The additional code.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the ADDCODE field.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "AdditionalInfo": {
+                    "description": "The room designation or other additional information.",
+                    "longDescription": "The value shall conform to the requirements of the LOC field as defined in RFC5139.  Provides additional information.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_7_0"
+                },
+                "Building": {
+                    "description": "The name of the building.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the BLD field.  Names the building.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "City": {
+                    "description": "City, township, or shi (JP).",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the A3 field.  Names a city, township, or shi (JP).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Community": {
+                    "description": "The postal community name.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the PCN field.  A postal community name.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Country": {
+                    "description": "The country.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the Country field.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "District": {
+                    "description": "A county, parish, gun (JP), or district (IN).",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the A2 field.  Names a county, parish, gun (JP), or district (IN).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Division": {
+                    "description": "City division, borough, city district, ward, or chou (JP).",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the A4 field.  Names a city division, borough, city district, ward, or chou (JP).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Floor": {
+                    "description": "The floor.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the FLR field.  Provides a floor designation.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "GPSCoords": {
+                    "deprecated": "This property has been deprecated in favor of the Longitude and Latitude properties.",
+                    "description": "The GPS coordinates of the part.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the ADDCODE field.  Shall contain the GPS coordinates of the location.  If furnished, expressed in the '[-][nn]n.nnnnnn, [-][nn]n.nnnnn' format.  For example, two comma-separated positive or negative numbers with six decimal places of precision.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0",
+                    "versionDeprecated": "v1_6_0"
+                },
+                "HouseNumber": {
+                    "description": "The numeric portion of house number.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the HNO field.  The numeric portion of the house number.",
+                    "readonly": false,
+                    "type": [
+                        "integer",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "HouseNumberSuffix": {
+                    "description": "The house number suffix.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the HNS field.  Provides a suffix to a house number, (F, B, or 1/2).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Landmark": {
+                    "description": "The landmark.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the LMK field.  Identifies a landmark or vanity address.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "LeadingStreetDirection": {
+                    "description": "A leading street direction.",
+                    "longDescription": "The value shall conform to the requirements of the PRD field as defined in RFC5139.  Names a leading street direction, (N, W, or SE).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Location": {
+                    "deprecated": "This property has been deprecated in favor of the AdditionalInfo property.",
+                    "description": "The room designation or other additional information.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the LOC field.  Provides additional information.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0",
+                    "versionDeprecated": "v1_7_0"
+                },
+                "Name": {
+                    "description": "The name.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the NAM field.  Names the occupant.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Neighborhood": {
+                    "description": "Neighborhood or block.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the A5 field.  Names a neighborhood or block.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "POBox": {
+                    "description": "The post office box (PO box).",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the POBOX field.  A post office box (PO box).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "PlaceType": {
+                    "description": "The description of the type of place that is addressed.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the PLC field.  Examples include office and residence.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "PostalCode": {
+                    "description": "The postal code or zip code.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the PC field.  A postal code (or zip code).",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Road": {
+                    "description": "The primary road or street.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the RD field.  Designates a primary road or street.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "RoadBranch": {
+                    "description": "The road branch.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the RDBR field.  Shall contain a post office box (PO box) road branch.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "RoadPostModifier": {
+                    "description": "The road post-modifier.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the POM field.  For example, Extended.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "RoadPreModifier": {
+                    "description": "The road pre-modifier.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the PRM field.  For example, Old or New.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "RoadSection": {
+                    "description": "The road section.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the RDSEC field.  A road section.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "RoadSubBranch": {
+                    "description": "The road sub branch.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the RDSUBBR field.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Room": {
+                    "description": "The name or number of the room.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the ROOM field.  A name or number of a room to locate the resource within the unit.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Seat": {
+                    "description": "The seat, such as the desk, cubicle, or workstation.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the SEAT field.  A name or number of a seat, such as the desk, cubicle, or workstation.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Street": {
+                    "description": "Street name.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the A6 field.  Names a street.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "StreetSuffix": {
+                    "description": "Avenue, Platz, Street, Circle.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the STS field.  Names a street suffix.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Territory": {
+                    "description": "A top-level subdivision within a country.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the A1 field when it names a territory, state, region, province, or prefecture within a country.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "TrailingStreetSuffix": {
+                    "description": "A trailing street suffix.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the POD field.  Names a trailing street suffix.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                },
+                "Unit": {
+                    "description": "The name or number of the apartment unit or suite.",
+                    "longDescription": "The value shall conform to the RFC5139-defined requirements of the UNIT field.  The name or number of a unit, such as the apartment or suite, to locate the resource.",
+                    "readonly": false,
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "versionAdded": "v1_3_0"
+                }
+            },
+            "type": "object"
+        },
+        "RackUnits": {
+            "description": "The type of rack unit in use.",
+            "enum": [
+                "OpenU",
+                "EIA_310"
+            ],
+            "enumDescriptions": {
+                "EIA_310": "A rack unit that is equal to 1.75 in (44.45 mm).",
+                "OpenU": "A rack unit that is equal to 48 mm (1.89 in)."
+            },
+            "enumLongDescriptions": {
+                "EIA_310": "Rack units shall conform to the EIA-310 standard.",
+                "OpenU": "Rack units shall be specified in terms of the Open Compute Open Rack Specification."
+            },
+            "longDescription": "Enumeration literals shall name the type of rack unit in use.",
+            "type": "string"
+        },
+        "Reference": {
+            "description": "The reference area for the location of the part.",
+            "enum": [
+                "Top",
+                "Bottom",
+                "Front",
+                "Rear",
+                "Left",
+                "Right",
+                "Middle"
+            ],
+            "enumDescriptions": {
+                "Bottom": "The part is in the bottom of the unit.",
+                "Front": "The part is in the front of the unit.",
+                "Left": "The part is on the left side of of the unit.",
+                "Middle": "The part is in the middle of the unit.",
+                "Rear": "The part is in the rear of the unit.",
+                "Right": "The part is on the right side of the unit.",
+                "Top": "The part is in the top of the unit."
+            },
+            "enumLongDescriptions": {
+                "Bottom": "This value shall be used to indicate the part is in the bottom of the unit.",
+                "Front": "This value shall be used to indicate the part is in the front of the unit.",
+                "Left": "This value shall be used to indicate the part is on the left side of of the unit.",
+                "Middle": "This value shall be used to indicate the part is in the middle of the unit.",
+                "Rear": "This value shall be used to indicate the part is in the rear of the unit.",
+                "Right": "This value shall be used to indicate the part is on the right side of the unit.",
+                "Top": "This value shall be used to indicate the part is in the top of the unit."
+            },
+            "longDescription": "The enumerated literals shall name the reference for the part location.",
+            "type": "string"
+        },
+        "ReferenceableMember": {
+            "additionalProperties": false,
+            "description": "The base type for addressable members of an array.",
+            "longDescription": "References array members by using the value returned in the @odata.id property, which may be a dereferenceable URL.  The @odata.id of this entity shall contain the location of this element within an item.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "MemberId": {
+                    "description": "The identifier for the member within the collection.",
+                    "longDescription": "This property shall uniquely identify the member within the collection.  For services supporting Redfish v1.6 or higher, this value shall contain the zero-based array index.",
+                    "readonly": true,
+                    "type": "string"
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "required": [
+                "MemberId",
+                "@odata.id"
+            ],
+            "type": "object"
+        },
+        "Resource": {
+            "additionalProperties": false,
+            "description": "The base type for resources and members that can be linked to.",
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Id",
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties that this object contains shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "required": [
+                "Id",
+                "Name",
+                "@odata.id",
+                "@odata.type"
+            ],
+            "type": "object"
+        },
+        "ResourceCollection": {
+            "additionalProperties": false,
+            "patternProperties": {
+                "^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\\.[a-zA-Z_][a-zA-Z0-9_]*$": {
+                    "description": "This property shall specify a valid odata or Redfish property.",
+                    "type": [
+                        "array",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "null",
+                        "object",
+                        "string"
+                    ]
+                }
+            },
+            "properties": {
+                "@odata.context": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/context"
+                },
+                "@odata.etag": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/etag"
+                },
+                "@odata.id": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/id"
+                },
+                "@odata.type": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/odata-v4.json#/definitions/type"
+                },
+                "Description": {
+                    "anyOf": [
+                        {
+                            "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Description"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "readonly": true
+                },
+                "Name": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Name",
+                    "readonly": true
+                },
+                "Oem": {
+                    "$ref": "http://redfish.dmtf.org/schemas/v1/Resource.json#/definitions/Oem",
+                    "description": "The OEM extension property.",
+                    "longDescription": "This property shall contain the OEM extensions.  All values for properties contained in this object shall conform to the Redfish Specification-described requirements."
+                }
+            },
+            "required": [
+                "Name",
+                "@odata.id",
+                "@odata.type"
+            ],
+            "type": "object"
+        }
+    },
+    "owningEntity": "DMTF",
+    "release": "2019.4",
+    "title": "#Resource.v1_9_1"
+}

--- a/doc-generator/tests/samples/properties_with_same_name/manager/notes.txt
+++ b/doc-generator/tests/samples/properties_with_same_name/manager/notes.txt
@@ -1,0 +1,8 @@
+In the Manager schema, there are two properties named
+"ConnectTypesSupported." One is within GraphicalConsole and the other
+within CommandShell, and they have distinct definitions.
+
+Previous versions of the doc generator assumed that a property name
+was unique within a schema, and would expand just one of these
+ConnectTypesSupported properties in the "Property details"
+section. They should both appear, with distinct headings.

--- a/doc-generator/tests/samples/properties_with_same_name/manager/odata-v4.json
+++ b/doc-generator/tests/samples/properties_with_same_name/manager/odata-v4.json
@@ -1,0 +1,56 @@
+{
+    "$id": "http://redfish.dmtf.org/schemas/v1/odata-v4.json",
+    "$schema": "http://redfish.dmtf.org/schemas/v1/redfish-schema-v1.json",
+    "definitions": {
+        "context": {
+            "type": "string",
+            "format": "uri-reference",
+            "readonly": true,
+            "description": "The OData description of a payload.",
+            "longDescription": "The value of this property shall be the context URL that describes the resource according to OData-Protocol and shall be of the form defined in the Redfish specification."
+        },
+        "id": {
+            "type": "string",
+            "format": "uri-reference",
+            "readonly": true,
+            "description": "The unique identifier for a resource.",
+            "longDescription": "The value of this property shall be the unique identifier for the resource and it shall be of the form defined in the Redfish specification."
+        },
+        "idRef": {
+            "type": "object",
+            "properties": {
+                "@odata.id": {
+                    "$ref": "#/definitions/id"
+                }
+            },
+            "additionalProperties": false,
+            "description": "A reference to a resource.",
+            "longDescription": "The value of this property shall be used for references to a resource."
+        },
+        "type": {
+            "type": "string",
+            "readonly": true,
+            "description": "The type of a resource.",
+            "longDescription": "The value of this property shall be a URI fragment that specifies the type of the resource and it shall be of the form defined in the Redfish specification."
+        },
+        "count": {
+            "type": "integer",
+            "readonly": true,
+            "description": "The number of items in a collection.",
+            "longDescription": "The value of this property shall be an integer representing the number of items in a collection."
+        },
+        "etag": {
+            "type": "string",
+            "readonly": true,
+            "description": "The current ETag of the resource.",
+            "longDescription": "The value of this property shall be a string that is defined by the ETag HTTP header definition in RFC7232."
+        },
+        "nextLink": {
+            "type": "string",
+            "format": "uri-reference",
+            "readonly": true,
+            "description": "The URI to the resource containing the next set of partial members.",
+            "longDescription": "The value of this property shall be a URI to a resource, with the same @odata.type, containing the next set of partial members."
+        }
+    }
+}

--- a/doc-generator/tests/test_properties_with_same_name.py
+++ b/doc-generator/tests/test_properties_with_same_name.py
@@ -49,8 +49,10 @@ def test_properties_with_same_name_md(mockRequest):
 
     prop_details = docGen.generator.this_section.get('property_details', {})
     # Property details should have been collected for the following (and only these):
-    expected_prop_details = ['ResetType', 'ConnectTypesSupported', 'ManagerType', 'PowerState']
-    assert [x for x in prop_details.keys()] == expected_prop_details
+    expected_prop_details = ['ConnectTypesSupported', 'ManagerType', 'PowerState', 'ResetType']
+    found_prop_details = [x for x in prop_details.keys()]
+    found_prop_details.sort()
+    assert found_prop_details == expected_prop_details
 
     # The following number of definitions should be captured for each:
     assert len(prop_details['ResetType'].keys()) == 2

--- a/doc-generator/tests/test_properties_with_same_name.py
+++ b/doc-generator/tests/test_properties_with_same_name.py
@@ -1,0 +1,65 @@
+# Copyright Notice:
+# Copyright 2020 Distributed Management Task Force, Inc. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Tools/blob/master/LICENSE.md
+
+"""
+File: test_combine_properties_with_same_name.py
+
+Brief: Verify that properties with the same name, within different objects in the same schema,
+       and defined as references to distinct definitions, are properly identified, with
+       both properties expanded in the Property details section.
+"""
+
+import os
+import copy
+from unittest.mock import patch
+import pytest
+from doc_generator import DocGenerator
+
+testcase_path = os.path.join('tests', 'samples', 'properties_with_same_name')
+
+base_config = {
+    'excluded_by_match': ['@odata.count', '@odata.navigationLink'],
+    'profile_resources': {},
+    'units_translation': {},
+    'excluded_annotations_by_match': ['@odata.count', '@odata.navigationLink'],
+    'excluded_schemas': [],
+    'excluded_properties': ['@odata.id', '@odata.context', '@odata.type'],
+    'excluded_pattern_props': [r'^([a-zA-Z_][a-zA-Z0-9_]*)?@(odata|Redfish|Message)\.[a-zA-Z_][a-zA-Z0-9_.]+$'],
+    'uri_replacements': {},
+    'wants_common_objects': True,
+    'profile': {},
+    'escape_chars': [],
+    'output_format': 'markdown',
+}
+
+
+@patch('urllib.request') # so we don't make HTTP requests. NB: samples should not call for outside resources.
+def test_properties_with_same_name_md(mockRequest):
+    """ Tests an example schema with two properties with the same name """
+    config = copy.deepcopy(base_config)
+
+    input_dir = os.path.abspath(os.path.join(testcase_path, 'manager'))
+
+    config['uri_to_local'] = {'redfish.dmtf.org/schemas/v1': input_dir}
+    config['local_to_uri'] = { input_dir : 'redfish.dmtf.org/schemas/v1'}
+
+    docGen = DocGenerator([ input_dir ], '/dev/null', config)
+    output = docGen.generate_docs()
+
+    prop_details = docGen.generator.this_section.get('property_details', {})
+    # Property details should have been collected for the following (and only these):
+    expected_prop_details = ['ResetType', 'ConnectTypesSupported', 'ManagerType', 'PowerState']
+    assert [x for x in prop_details.keys()] == expected_prop_details
+
+    # The following number of definitions should be captured for each:
+    assert len(prop_details['ResetType'].keys()) == 2
+    assert len(prop_details['ConnectTypesSupported'].keys()) == 3
+    assert len(prop_details['ManagerType'].keys()) == 1
+    assert len(prop_details['PowerState'].keys()) == 1
+
+    # Spot-check the output as well. These are the headings that should appear for ConnectTypesSupported:
+    assert "### ConnectTypesSupported" in output
+    assert "In CommandShell:" in output
+    assert "In GraphicalConsole:" in output
+    assert "In SerialConsole:" in output


### PR DESCRIPTION
Fixes a bug wherein if two or more enums used in the same schema had the same name, only one of them would appear in the Property Details section. (Example: ConnectTypesSupported is used in three different properties in the Manager schema, with three different definitions.) 